### PR TITLE
fix: correct tlog log-node removal during close

### DIFF
--- a/src/tlog.c
+++ b/src/tlog.c
@@ -1470,6 +1470,7 @@ static int _tlog_wait_pids(void)
 
 static int _tlog_close(struct tlog_log *log, int wait_hang)
 {
+    int removed = 0;
     struct tlog_log *next = tlog.log;
 
     if (log == NULL) {
@@ -1497,23 +1498,23 @@ static int _tlog_close(struct tlog_log *log, int wait_hang)
 
     if (next == log) {
         tlog.log = next->next;
-        free(log);
-        return 0;
-    }
-
-    while (next) {
-        if (next->next == log) {
-            next->next = log->next;
-            free(log);
-            return -1;
+        removed = 1;
+    } else {
+        while (next) {
+            if (next->next == log) {
+                next->next = log->next;
+                removed = 1;
+                break;
+            }
+            next = next->next;
         }
-        next = next->next;
     }
 
     pthread_cond_destroy(&log->client_cond);
     pthread_mutex_destroy(&log->lock);
+    free(log);
 
-    return 0;
+    return removed ? 0 : -1;
 }
 
 static struct tlog_log *_tlog_next_log(struct tlog_log *last_log)


### PR DESCRIPTION
### Motivation
- Long-running smartdns instances could crash (SIGSEGV) during shutdown because the tlog worker loop relies on `_tlog_close()` return value to update iterator state, and `_tlog_close()` could free a log node but return failure, leaving dangling pointers.
- The previous code path for removing a non-head log freed the log and returned `-1`, which could cause use-after-free in the background worker.
- Cleanup was inconsistent because some removal paths returned early and skipped destroying per-log condition/mutex.

### Description
- Introduced a `removed` flag in `_tlog_close()` to track whether the node was unlinked from the circular list. 
- Made head and non-head removal paths set `removed = 1` and break/continue uniformly instead of freeing and returning early.
- Ensured `pthread_cond_destroy()` and `pthread_mutex_destroy()` are always called before `free(log)` so per-log resources are consistently cleaned.
- Unified return semantics so `_tlog_close()` returns `0` on successful removal and `-1` when the node was not found or a zip process is still running.

### Testing
- Built the project successfully with `make -C src -j4` and the linker produced the `smartdns` binary without errors.
- The change was validated by compiling the modified `src/tlog.c` and ensuring no build-time errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c788e8975c832682b15d7d87626210)