### PR TITLE
fix: handle CNAME-only AAAA upstream responses without fallback

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,10 +1,7 @@
 name: C/C++ CI
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,7 +1,10 @@
 name: C/C++ CI
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/src/dns_server/answer.c
+++ b/src/dns_server/answer.c
@@ -428,7 +428,13 @@ int _dns_server_process_answer(struct dns_request *request, const char *domain, 
 					continue;
 				}
 				safe_strncpy(cname, domain_cname, DNS_MAX_CNAME_LEN);
+				if (request->conf->dns_force_no_cname == 0) {
+					request->has_cname = 1;
+					safe_strncpy(request->cname, cname, sizeof(request->cname));
+				}
 				request->ttl_cname = _dns_server_get_conf_ttl(request, ttl);
+				request->rcode = packet->head.rcode;
+				is_rcode_set = 1;
 				tlog(TLOG_DEBUG, "name: %s ttl: %d cname: %s\n", domain_name, ttl, cname);
 			} break;
 			case DNS_T_HTTPS: {

--- a/test/cases/test-cname.cc
+++ b/test/cases/test-cname.cc
@@ -193,3 +193,31 @@ server 127.0.0.1:61053
 	EXPECT_EQ(client.GetAnswer()[0].GetName(), "s.a.com");
 	EXPECT_EQ(client.GetAnswer()[0].GetData(), "4.5.6.7");
 }
+
+TEST_F(Cname, aaaa_with_cname_only)
+{
+	smartdns::MockServer server_upstream;
+	smartdns::Server server;
+
+	server_upstream.Start("udp://0.0.0.0:61053", [](struct smartdns::ServerRequestContext *request) {
+		dns_add_CNAME(request->response_packet, DNS_RRS_AN, "perfops.byte-test.com", 1,
+					  "perfops.byte-test.com.bplslb.com");
+		if (request->qtype == DNS_T_A && request->domain == "perfops.byte-test.com.bplslb.com") {
+			smartdns::MockServer::AddIP(request, request->domain.c_str(), "1.2.3.4", 60);
+		}
+
+		return smartdns::SERVER_REQUEST_OK;
+	});
+
+	server.Start(R"""(bind [::]:60053
+server 127.0.0.1:61053
+)""");
+
+	smartdns::Client client;
+	ASSERT_TRUE(client.Query("perfops.byte-test.com", 60053, DNS_T_AAAA));
+	std::cout << client.GetResult() << std::endl;
+	ASSERT_EQ(client.GetStatus(), "NOERROR");
+	ASSERT_EQ(client.GetAnswerNum(), 1);
+	EXPECT_EQ(client.GetAnswer()[0].GetName(), "perfops.byte-test.com");
+	EXPECT_EQ(client.GetAnswer()[0].GetData(), "perfops.byte-test.com.bplslb.com.");
+}

--- a/test/cases/test-cname.cc
+++ b/test/cases/test-cname.cc
@@ -214,7 +214,7 @@ server 127.0.0.1:61053
 )""");
 
 	smartdns::Client client;
-	ASSERT_TRUE(client.Query("perfops.byte-test.com", 60053, DNS_T_AAAA));
+	ASSERT_TRUE(client.Query("AAAA perfops.byte-test.com", 60053));
 	std::cout << client.GetResult() << std::endl;
 	ASSERT_EQ(client.GetStatus(), "NOERROR");
 	ASSERT_EQ(client.GetAnswerNum(), 1);


### PR DESCRIPTION
### Motivation
- Upstream answers that contain only a matching `CNAME` RR and no `AAAA` must be treated as a valid `NOERROR` response and returned as such (per RFC 1034) instead of being classified as invalid and triggering fallback for `AAAA` queries.

### Description
- When parsing `CNAME` RRs in `_dns_server_process_answer`, persist the CNAME metadata by setting `request->has_cname` and copying into `request->cname` (honoring `request->conf->dns_force_no_cname`), and mark the response valid by setting `request->rcode` and `is_rcode_set` so a CNAME-only NOERROR is accepted; change is in `src/dns_server/answer.c`.
- Added a regression test `Cname.aaaa_with_cname_only` in `test/cases/test-cname.cc` which simulates `perfops.byte-test.com -> CNAME perfops.byte-test.com.bplslb.com` with no AAAA on the target and verifies a `NOERROR` response containing the CNAME.
- The change is intentionally minimal and preserves existing logic and configuration (`dns_force_no_cname`) without introducing new variables.

### Testing
- Added unit test `test/cases/test-cname.cc::Cname.aaaa_with_cname_only` to cover the described scenario and assert `NOERROR + CNAME` for an `AAAA` query; the test file is present in the tree.
- Attempted to build the test binary with `cd test && make -j4 test.bin`, but the build failed in this environment due to a missing `gtest/gtest.h` dependency so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9a89c1c8326bd99ea3cfc100593)