### PR TITLE
Retry when all IPs are ignored and refine CNAME handling; add tests

### DIFF
--- a/src/dns_server/answer.c
+++ b/src/dns_server/answer.c
@@ -428,6 +428,10 @@ int _dns_server_process_answer(struct dns_request *request, const char *domain, 
 					continue;
 				}
 				safe_strncpy(cname, domain_cname, DNS_MAX_CNAME_LEN);
+				if (request->conf->dns_force_no_cname == 0) {
+					request->has_cname = 1;
+					safe_strncpy(request->cname, cname, sizeof(request->cname));
+				}
 				request->ttl_cname = _dns_server_get_conf_ttl(request, ttl);
 				tlog(TLOG_DEBUG, "name: %s ttl: %d cname: %s\n", domain_name, ttl, cname);
 			} break;
@@ -484,9 +488,13 @@ int _dns_server_process_answer(struct dns_request *request, const char *domain, 
 		request->rcode = packet->head.rcode;
 	}
 
-	/* return NOERROR if all ips are skipped */
+	/* retry if all ips are skipped */
 	if (request->rcode == DNS_RC_SERVFAIL && has_result == 1 && is_skip == 1) {
+		tlog(TLOG_DEBUG, "all result is ignored, %s qtype: %d, rcode: %d, id: %d, retry.", domain, request->qtype,
+			 packet->head.rcode, packet->head.id);
 		request->rcode = DNS_RC_NOERROR;
+		request->passthrough = 1;
+		return DNS_CLIENT_ACTION_RETRY;
 	}
 
 	if (has_result == 0 && request->rcode == DNS_RC_NOERROR && packet->head.tc == 1 && request->has_ip == 0 &&
@@ -497,6 +505,10 @@ int _dns_server_process_answer(struct dns_request *request, const char *domain, 
 	}
 
 	if (is_rcode_set == 0 && has_result == 1 && is_skip == 0) {
+		if (cname[0] != '\0') {
+			return DNS_CLIENT_ACTION_OK;
+		}
+
 		/* need retry for some server. */
 		return DNS_CLIENT_ACTION_MAY_RETRY;
 	}

--- a/test/cases/test-cname.cc
+++ b/test/cases/test-cname.cc
@@ -193,3 +193,70 @@ server 127.0.0.1:61053
 	EXPECT_EQ(client.GetAnswer()[0].GetName(), "s.a.com");
 	EXPECT_EQ(client.GetAnswer()[0].GetData(), "4.5.6.7");
 }
+
+TEST_F(Cname, aaaa_with_cname_only)
+{
+	smartdns::MockServer server_upstream;
+	smartdns::Server server;
+
+	server_upstream.Start("udp://0.0.0.0:61053", [](struct smartdns::ServerRequestContext *request) {
+		dns_add_domain(request->response_packet, request->domain.c_str(), request->qtype, DNS_C_IN);
+		dns_add_CNAME(request->response_packet, DNS_RRS_AN, "perfops.byte-test.com", 1,
+					  "perfops.byte-test.com.bplslb.com");
+		if (request->qtype == DNS_T_A && request->domain == "perfops.byte-test.com.bplslb.com") {
+			smartdns::MockServer::AddIP(request, request->domain.c_str(), "1.2.3.4", 60);
+		}
+
+		return smartdns::SERVER_REQUEST_OK;
+	});
+
+	server.Start(R"""(bind [::]:60053
+server 127.0.0.1:61053
+)""");
+
+	smartdns::Client client;
+	ASSERT_TRUE(client.Query("AAAA perfops.byte-test.com", 60053));
+	std::cout << client.GetResult() << std::endl;
+	ASSERT_EQ(client.GetStatus(), "NOERROR");
+	ASSERT_EQ(client.GetAnswerNum(), 1);
+	EXPECT_EQ(client.GetAnswer()[0].GetName(), "perfops.byte-test.com");
+	EXPECT_EQ(client.GetAnswer()[0].GetData(), "perfops.byte-test.com.bplslb.com.");
+}
+
+TEST_F(Cname, cname_retry_when_all_target_ip_ignored)
+{
+	smartdns::MockServer server_upstream;
+	smartdns::Server server;
+
+	int request_count = 0;
+	server_upstream.Start("udp://0.0.0.0:61053", [&request_count](struct smartdns::ServerRequestContext *request) {
+		dns_add_domain(request->response_packet, request->domain.c_str(), request->qtype, DNS_C_IN);
+		dns_add_CNAME(request->response_packet, DNS_RRS_AN, "perfops.byte-test.com", 1,
+					  "perfops.byte-test.com.bplslb.com");
+
+		request_count++;
+		if (request_count == 1) {
+			smartdns::MockServer::AddIP(request, "perfops.byte-test.com.bplslb.com", "1.2.3.4", 60);
+			smartdns::MockServer::AddIP(request, "perfops.byte-test.com.bplslb.com", "2001:db8::1", 60);
+		} else {
+			smartdns::MockServer::AddIP(request, "perfops.byte-test.com.bplslb.com", "2001:db8::2", 60);
+		}
+
+		return smartdns::SERVER_REQUEST_OK;
+	});
+
+	server.Start(R"""(bind [::]:60053
+server 127.0.0.1:61053
+ignore-ip 1.2.3.4
+ignore-ip 2001:db8::1
+)""");
+
+	smartdns::Client client;
+	ASSERT_TRUE(client.Query("AAAA perfops.byte-test.com", 60053));
+	std::cout << client.GetResult() << std::endl;
+	ASSERT_EQ(client.GetStatus(), "NOERROR");
+	ASSERT_EQ(client.GetAnswerNum(), 2);
+	EXPECT_EQ(client.GetAnswer()[0].GetData(), "perfops.byte-test.com.bplslb.com.");
+	EXPECT_EQ(client.GetAnswer()[1].GetData(), "2001:db8::2");
+	EXPECT_GE(request_count, 2);
+}

--- a/test/cases/test-ip-rule.cc
+++ b/test/cases/test-ip-rule.cc
@@ -273,6 +273,62 @@ ignore-ip 0.0.0.0/0
 	EXPECT_EQ(client.GetStatus(), "NOERROR");
 }
 
+TEST_F(IPRule, retry_when_all_ip_ignored)
+{
+	smartdns::MockServer server_upstream;
+	smartdns::Server server;
+
+	int request_count = 0;
+	server_upstream.Start("udp://0.0.0.0:61053", [&request_count](struct smartdns::ServerRequestContext *request) {
+		dns_add_domain(request->response_packet, request->domain.c_str(), request->qtype, DNS_C_IN);
+		request_count++;
+		if (request_count == 1) {
+			smartdns::MockServer::AddIP(request, request->domain.c_str(), "1.2.3.4", 611);
+		} else {
+			smartdns::MockServer::AddIP(request, request->domain.c_str(), "4.5.6.7", 611);
+		}
+
+		return smartdns::SERVER_REQUEST_OK;
+	});
+
+	server.Start(R"""(bind [::]:60053
+server udp://127.0.0.1:61053
+ignore-ip 1.2.3.4
+)""");
+	smartdns::Client client;
+	ASSERT_TRUE(client.Query("a.com", 60053));
+	std::cout << client.GetResult() << std::endl;
+	ASSERT_EQ(client.GetAnswerNum(), 1);
+	EXPECT_EQ(client.GetStatus(), "NOERROR");
+	EXPECT_EQ(client.GetAnswer()[0].GetData(), "4.5.6.7");
+	EXPECT_GE(request_count, 2);
+}
+
+TEST_F(IPRule, noerror_when_retry_exhausted_and_all_ip_ignored)
+{
+	smartdns::MockServer server_upstream;
+	smartdns::Server server;
+
+	int request_count = 0;
+	server_upstream.Start("udp://0.0.0.0:61053", [&request_count](struct smartdns::ServerRequestContext *request) {
+		dns_add_domain(request->response_packet, request->domain.c_str(), request->qtype, DNS_C_IN);
+		request_count++;
+		smartdns::MockServer::AddIP(request, request->domain.c_str(), "1.2.3.4", 611);
+		return smartdns::SERVER_REQUEST_OK;
+	});
+
+	server.Start(R"""(bind [::]:60053
+server udp://127.0.0.1:61053
+ignore-ip 1.2.3.4
+)""");
+	smartdns::Client client;
+	ASSERT_TRUE(client.Query("a.com", 60053));
+	std::cout << client.GetResult() << std::endl;
+	ASSERT_EQ(client.GetAnswerNum(), 0);
+	EXPECT_EQ(client.GetStatus(), "NOERROR");
+	EXPECT_GE(request_count, 2);
+}
+
 TEST_F(IPRule, no_ignore_ip_by_domain)
 {
 	smartdns::MockServer server_upstream;


### PR DESCRIPTION
### Motivation
- Ensure the client will retry upstream when a response contains answers but all IPs were ignored, instead of returning a silent failure. 
- Avoid treating CNAMEs as visible to the request when the configuration forbids it via `dns_force_no_cname`. 
- Prevent unnecessary "may retry" behavior when there is a valid CNAME answer to satisfy the query.

### Description
- Only set `request->has_cname` and copy into `request->cname` when `request->conf->dns_force_no_cname == 0` to honor the configuration flag. 
- When `request->rcode == DNS_RC_SERVFAIL` and there were results but all were skipped, set `request->passthrough = 1`, log the event, and return `DNS_CLIENT_ACTION_RETRY` so the client retries the upstream server. 
- When there are answers and no rcode was explicitly set, return `DNS_CLIENT_ACTION_OK` immediately if a `cname` was recorded, avoiding an unnecessary `MAY_RETRY`. 
- Added unit tests to cover the new behaviors: tests in `test/cases/test-cname.cc` (`aaaa_with_cname_only`, `cname_retry_when_all_target_ip_ignored`) and in `test/cases/test-ip-rule.cc` (`retry_when_all_ip_ignored`, `noerror_when_retry_exhausted_and_all_ip_ignored`).

### Testing
- Ran the unit tests including the modified `test-cname` and `test-ip-rule` cases via the test suite; the newly added tests executed and passed. 
- Existing related tests were exercised to verify no regressions in CNAME and IP-ignore handling and they passed. 
- No automated test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b9a89c1c8326bd99ea3cfc100593)