### PR TITLE
Fix plugin teardown race during process exit

### DIFF
--- a/src/dns_plugin.c
+++ b/src/dns_plugin.c
@@ -453,11 +453,13 @@ void dns_server_plugin_exit(void)
 		return;
 	}
 
+	/* stop new callbacks from entering plugins.lock while teardown is in progress */
+	atomic_set(&is_plugin_init, 0);
+
 	_dns_plugin_remove_all_ops();
 	_dns_plugin_remove_all();
 
 	pthread_rwlock_destroy(&plugins.lock);
-	atomic_set(&is_plugin_init, 0);
 	return;
 }
 

--- a/src/smartdns.c
+++ b/src/smartdns.c
@@ -713,11 +713,11 @@ static int _smartdns_run(void)
 
 static void _smartdns_exit(void)
 {
+	dns_server_exit();
+	dns_client_exit();
 	_smartdns_plugin_exit();
 	proxy_exit();
 	fast_ping_exit();
-	dns_server_exit();
-	dns_client_exit();
 	dns_stats_exit();
 	_smartdns_destroy_ssl();
 	dns_timer_destroy();


### PR DESCRIPTION
### Motivation
- Buffered stdout logging from plugins can be flushed after threads invoke plugin callbacks, creating a race during shutdown that may crash when plugin data structures are torn down. 
- The most dangerous call is `pthread_rwlock_destroy(&plugins.lock)` inside `dns_server_plugin_exit()`, which can run while other threads still enter plugin callbacks through the `_smartdns_exit()` shutdown path.

### Description
- Prevent new plugin callbacks entering by setting `is_plugin_init` to `0` at the start of `dns_server_plugin_exit()` (file `src/dns_plugin.c`).
- Reduce teardown races by stopping the DNS server and client earlier in `_smartdns_exit()` before calling `_smartdns_plugin_exit()` (file `src/smartdns.c`).
- Modified files: `src/dns_plugin.c` and `src/smartdns.c`.

### Testing
- Built the project with `make -j2` and the build completed successfully.
- Changes were committed with message `fix plugin shutdown race during exit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef3db6bb88326a289158d0695c975)