### PR TITLE
Check hash table allocation in dns_cache_init and log error

### DIFF
--- a/src/dns_cache.c
+++ b/src/dns_cache.c
@@ -72,6 +72,11 @@ int dns_cache_init(int size, int mem_size, dns_cache_callback timeout_callback)
 	}
 
 	hash_table_init(dns_cache_head.cache_hash, bits);
+	if (dns_cache_head.cache_hash.table == NULL) {
+		tlog(TLOG_ERROR, "init dns cache failed, alloc hash table failed, bits = %d", bits);
+		return -1;
+	}
+
 	atomic_set(&dns_cache_head.num, 0);
 	atomic_set(&dns_cache_head.mem_size, 0);
 	dns_cache_head.size = size;


### PR DESCRIPTION
### Motivation
- Prevent dereferencing a NULL hash table when `hash_table_init` fails by validating the allocation and returning an error.

### Description
- Add a NULL check after `hash_table_init(dns_cache_head.cache_hash, bits)` that logs an error with `tlog(TLOG_ERROR, ...)` and returns `-1` when `dns_cache_head.cache_hash.table == NULL`.

### Testing
- Rebuilt the project and ran the existing automated test suite; build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efea91cb1c8326bf243e472cb9ed3a)