### PR TITLE
Remove hostname datatype for SNI name option

### DIFF
--- a/package/luci/files/root/www/luci-static/resources/view/smartdns/smartdns.js
+++ b/package/luci/files/root/www/luci-static/resources/view/smartdns/smartdns.js
@@ -905,7 +905,6 @@ return view.extend({
 		o = s.taboption("advanced", form.Value, "host_name", _("TLS SNI name"),
 			_("Sets the server name indication for query. '-' for disable SNI name."))
 		o.default = ""
-		o.datatype = "hostname"
 		o.rempty = true
 		o.modalonly = true;
 		o.depends("type", "tls")


### PR DESCRIPTION
移除上游服务器高级设置中 TLS SNI 名称的输入限制 https://github.com/pymumu/smartdns/issues/2261